### PR TITLE
Add Troubleshooting section with fix for Linux users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 ![Scoreboard](../screenshots/10_Scoreboard.jpg)
 ![Win & Damage](../screenshots/14_Win.jpg)
 
+</div>
+
 ## Troubleshooting
 
 ### This HUD won't load on Linux!

--- a/README.md
+++ b/README.md
@@ -5,10 +5,16 @@
 
 **[SCREENSHOTS](../screenshots/showcase.md)** -
 **[INSTALLATION](https://github.com/Hypnootize/TF2-HUD-GitHub-Resources/blob/main/installation/windows_install.md)** -
-**[CONTRIBUTING](https://github.com/Hypnootize/TF2-HUD-GitHub-Resources/blob/main/contributing/github_contributing.md)**
+**[CONTRIBUTING](https://github.com/Hypnootize/TF2-HUD-GitHub-Resources/blob/main/contributing/github_contributing.md)** -
+**[TROUBLESHOOTING](#troubleshooting)**
 
 ![Main Menu](../screenshots/01_Main_Menu.jpg)
 ![Health Buff](../screenshots/06_Health_Buff.jpg)
 ![Health & Ammo Low](../screenshots/07_Health_Ammo_Low.jpg)
 ![Scoreboard](../screenshots/10_Scoreboard.jpg)
 ![Win & Damage](../screenshots/14_Win.jpg)
+
+## Troubleshooting
+
+### This HUD won't load on Linux!
+Rename the containing folder for the HUD within tf/custom (BX-Hud-master) to use an all-lowercase name (bx-hud-master). 


### PR DESCRIPTION
This HUD apparently officially does not support Linux, but it can be made to work just by renaming the folder for the HUD within tf/custom. This change makes users aware of this fix.